### PR TITLE
Optimize Python loops

### DIFF
--- a/dragonpilot/selfdrive/controls/lib/acm.py
+++ b/dragonpilot/selfdrive/controls/lib/acm.py
@@ -69,8 +69,8 @@ class ACM:
       return a_desired_trajectory
 
     # Suppress all braking to allow smooth coasting
-    for i in range(len(a_desired_trajectory)):
-      if a_desired_trajectory[i] < 0 and a_desired_trajectory[i] > self.allowed_brake_val:
+    for i, val in enumerate(a_desired_trajectory):
+      if val < 0 and val > self.allowed_brake_val:
         a_desired_trajectory[i] = 0.0
     return a_desired_trajectory
 

--- a/tools/lib/logreader.py
+++ b/tools/lib/logreader.py
@@ -294,7 +294,7 @@ class LogReader:
     return self.__lrs[i]
 
   def __iter__(self):
-    for i in range(len(self.logreader_identifiers)):
+    for i, _ in enumerate(self.logreader_identifiers):
       yield from self._get_lr(i)
 
   def _run_on_segment(self, func, i):

--- a/tools/replay/lib/rp_helpers.py
+++ b/tools/replay/lib/rp_helpers.py
@@ -33,8 +33,8 @@ def draw_path(path, lid_overlay, lid_color=None):
   x, y = np.asarray(path.x), np.asarray(path.y)
   # draw lidar path point on lidar
   if lid_color is not None and lid_overlay is not None:
-    for i in range(len(x)):
-      px, py = to_topdown_pt(x[i], y[i])
+    for xi, yi in zip(x, y, strict=True):
+      px, py = to_topdown_pt(xi, yi)
       if px != -1:
         lid_overlay[px, py] = lid_color
 

--- a/tools/replay/lib/ui_helpers.py
+++ b/tools/replay/lib/ui_helpers.py
@@ -78,8 +78,8 @@ def draw_path(path, color, img, calibration, top_down, lid_color=None, z_off=0):
   # find color in 8 bit
   if lid_color is not None and top_down is not None:
     tcolor = find_color(top_down[0], lid_color)
-    for i in range(len(x)):
-      px, py = to_topdown_pt(x[i], y[i])
+    for xi, yi in zip(x, y, strict=True):
+      px, py = to_topdown_pt(xi, yi)
       if px != -1:
         top_down[1][px, py] = tcolor
 
@@ -106,10 +106,10 @@ def init_plots(arr, name_to_arr_idx, plot_xlims, plot_ylims, plot_names, plot_co
   fig.set_facecolor((0.2, 0.2, 0.2))
 
   axs = []
-  for pn in range(len(plot_ylims)):
-    ax = fig.add_subplot(len(plot_ylims), 1, len(axs)+1)
-    ax.set_xlim(plot_xlims[pn][0], plot_xlims[pn][1])
-    ax.set_ylim(plot_ylims[pn][0], plot_ylims[pn][1])
+  for pn, (xlim, ylim) in enumerate(zip(plot_xlims, plot_ylims, strict=True)):
+    ax = fig.add_subplot(len(plot_ylims), 1, pn + 1)
+    ax.set_xlim(*xlim)
+    ax.set_ylim(*ylim)
     ax.patch.set_facecolor((0.4, 0.4, 0.4))
     axs.append(ax)
 
@@ -137,9 +137,9 @@ def init_plots(arr, name_to_arr_idx, plot_xlims, plot_ylims, plot_names, plot_co
   def draw_plots(arr):
     for ax in axs:
       ax.draw_artist(ax.patch)
-    for i in range(len(plots)):
-      plots[i].set_ydata(arr[:, idxs[i]])
-      axs[plot_select[i]].draw_artist(plots[i])
+    for plot, idx, select in zip(plots, idxs, plot_select, strict=True):
+      plot.set_ydata(arr[:, idx])
+      axs[select].draw_artist(plot)
 
     raw_data = canvas.buffer_rgba()
     plot_surface = pygame.image.frombuffer(raw_data, canvas.get_width_height(), "RGBA").convert()


### PR DESCRIPTION
## Summary
- simplify range loops
- use zip with strict to iterate sequences

## Testing
- `ruff check tools/replay/lib/ui_helpers.py tools/replay/lib/rp_helpers.py tools/lib/logreader.py dragonpilot/selfdrive/controls/lib/acm.py | head`
- `pytest tools/lib/tests/test_caching.py::TestCaching::test_read_through -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68481bea5e7c8327aefe2d41c40d63de